### PR TITLE
Invite through different apps

### DIFF
--- a/app/src/main/java/org/agrinext/agrimobile/Activities/FormGeneratorActivity.kt
+++ b/app/src/main/java/org/agrinext/agrimobile/Activities/FormGeneratorActivity.kt
@@ -16,13 +16,12 @@ class FormGeneratorActivity : BaseCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        this.doctype = intent.extras.get("DocType").toString()
 
         FormGeneraterUI(JSONObject(), JSONObject()).setContentView(this)
     }
 
     override fun onBackPressed() {
-
         finish()
-
     }
 }

--- a/app/src/main/java/org/agrinext/agrimobile/Activities/ListingActivity.kt
+++ b/app/src/main/java/org/agrinext/agrimobile/Activities/ListingActivity.kt
@@ -28,7 +28,7 @@ import org.jetbrains.anko.support.v4.startActivity
 import org.jetbrains.anko.support.v4.toast
 
 
-open class ListingActivity : Fragment() {
+open class ListingActivity : Fragment(), View.OnClickListener {
 
     internal lateinit var mRecyclerView: RecyclerView
     var recyclerAdapter: ListViewAdapter? = null
@@ -48,6 +48,12 @@ open class ListingActivity : Fragment() {
         val KEY_FILTERS = "filters"
         val SET_DOCTYPE = 400
         val SET_DOCTYPE_FILTERS = 401
+    }
+
+    override fun onClick(view: View?) {
+        var intent = Intent(activity, FormGeneratorActivity::class.java)
+        intent.putExtra("DocType", this.doctype)
+        startActivity(intent)
     }
 
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -291,7 +297,8 @@ open class ListingActivity : Fragment() {
                     recyclerAdapter!!.notifyDataSetChanged()
                 } else if (page == null) {
                     // specify and add an adapter
-                    recyclerAdapter = ListViewAdapter(recyclerModels, activity)
+                    recyclerAdapter = ListViewAdapter(recyclerModels)
+                    recyclerAdapter!!.setOnClickListener(this@ListingActivity)
 
                     if (mRecyclerView.adapter == null)
                         mRecyclerView.adapter = recyclerAdapter

--- a/app/src/main/java/org/agrinext/agrimobile/Activities/ListingActivity.kt
+++ b/app/src/main/java/org/agrinext/agrimobile/Activities/ListingActivity.kt
@@ -13,6 +13,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import android.content.Intent
 import android.support.v4.app.Fragment
+import android.support.v4.widget.SwipeRefreshLayout
 import android.util.Log
 import android.view.*
 import android.widget.*
@@ -41,6 +42,7 @@ open class ListingActivity : Fragment(), View.OnClickListener {
     var sortOrder: String? = "desc"
     var doctype: String? = null
     var doctypeMetaJson = JSONObject()
+    var swipeRefresh: SwipeRefreshLayout? = null
 
     companion object {
         val DOCTYPE_META = "DOCTYPE_META"
@@ -75,6 +77,8 @@ open class ListingActivity : Fragment(), View.OnClickListener {
         setupSortOrder()
 
         setRecycleViewScrollListener()
+
+        setupSwipeRefresh()
     }
 
 
@@ -305,6 +309,8 @@ open class ListingActivity : Fragment(), View.OnClickListener {
                 }
                 loadServerData = true
                 progressBar?.visibility = View.GONE
+                if(swipeRefresh!!.isRefreshing)
+                    swipeRefresh!!.setRefreshing(false)
             }
 
             override fun onErrorResponse(s: String) {
@@ -335,5 +341,16 @@ open class ListingActivity : Fragment(), View.OnClickListener {
             loadData(filters = filters!!)
             setRecycleViewScrollListener()
         }
+    }
+
+    fun setupSwipeRefresh() {
+        swipeRefresh = activity.find<SwipeRefreshLayout>(R.id.swipeRefresh)
+        swipeRefresh!!.setOnRefreshListener(
+                SwipeRefreshLayout.OnRefreshListener {
+                    recyclerModels = JSONArray()
+                    mRecyclerView.adapter = null
+                    loadData(filters = filters!!)
+                }
+        )
     }
 }

--- a/app/src/main/java/org/agrinext/agrimobile/Activities/ListingActivity.kt
+++ b/app/src/main/java/org/agrinext/agrimobile/Activities/ListingActivity.kt
@@ -64,7 +64,7 @@ open class ListingActivity : Fragment() {
 
         setupView()
 
-        setupSortSpinner()
+//        setupSortSpinner()
 
         setupSortOrder()
 
@@ -159,8 +159,12 @@ open class ListingActivity : Fragment() {
         val doctypeMetaString = pref.getString(keyDocTypeMeta, null)
         if (doctypeMetaString != null){
             this.doctypeMetaJson = JSONObject(doctypeMetaString)
+            setupSortSpinner()
         } else {
             FrappeClient(activity).retrieveDocTypeMeta(editor, keyDocTypeMeta, this.doctype)
+            android.os.Handler().postDelayed(
+                    { setupDocType() },
+                    500)
         }
     }
 

--- a/app/src/main/java/org/agrinext/agrimobile/Activities/MainActivity.kt
+++ b/app/src/main/java/org/agrinext/agrimobile/Activities/MainActivity.kt
@@ -3,6 +3,7 @@ package org.agrinext.agrimobile.Activities
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.Intent
+import android.content.Intent.createChooser
 import android.os.Bundle
 import android.support.annotation.Nullable
 import android.support.design.widget.NavigationView
@@ -91,7 +92,7 @@ class MainActivity : BaseCompatActivity(), NavigationView.OnNavigationItemSelect
                 setupFragment(ProduceActivity())
             }
             R.id.nav_invite -> {
-                share("https://agrinext.org")
+                shareInvite()
             }
             R.id.nav_locations -> {
                 setupFragment(ListingActivity())
@@ -112,6 +113,16 @@ class MainActivity : BaseCompatActivity(), NavigationView.OnNavigationItemSelect
         ft.replace(R.id.screen_area, fragment)
         ft.commit()
     }
+
+    fun shareInvite() {
+        var shareData = getString(R.string.shareData) + " https://agrinext.org"
+        val sendIntent = Intent()
+        sendIntent.action = Intent.ACTION_SEND
+        sendIntent.putExtra(Intent.EXTRA_TEXT, shareData)
+        sendIntent.type = "text/plain"
+        startActivity(createChooser(sendIntent, "Share"))
+    }
+
     fun fireUp() {
         mAccountManager = AccountManager.get(this)
         accounts = mAccountManager.getAccountsByType(BuildConfig.APPLICATION_ID)

--- a/app/src/main/java/org/agrinext/agrimobile/Android/ListViewAdapter.kt
+++ b/app/src/main/java/org/agrinext/agrimobile/Android/ListViewAdapter.kt
@@ -1,7 +1,6 @@
 package org.agrinext.agrimobile.Android
 
 import android.app.Activity
-import android.content.Intent
 import android.support.v7.widget.RecyclerView
 import android.util.Log
 import android.view.View
@@ -9,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.Filter
 import android.widget.Filterable
 import android.widget.TextView
-import org.agrinext.agrimobile.Activities.FormGeneratorActivity
 import org.agrinext.agrimobile.R
 import org.jetbrains.anko.AnkoContext
 import org.jetbrains.anko.find
@@ -23,10 +21,16 @@ import java.nio.file.Files.size
  * Created by revant on 28/12/17.
  */
 
-class ListViewAdapter(var doc_list:JSONArray, var context: Activity): RecyclerView.Adapter<ListViewAdapter.ViewHolder>(), Filterable {
+class ListViewAdapter(var doc_list:JSONArray): RecyclerView.Adapter<ListViewAdapter.ViewHolder>(), Filterable {
     fun setLoadDataCallback() {
 
     }
+
+    private var mCLickListener: View.OnClickListener? = null
+    fun setOnClickListener(listener: View.OnClickListener) {
+        mCLickListener = listener
+    }
+
     val immutable_doc_list = doc_list
     override fun getFilter(): Filter {
         return object : Filter() {
@@ -97,8 +101,6 @@ class ListViewAdapter(var doc_list:JSONArray, var context: Activity): RecyclerVi
         val jsonObject = doc_list.getJSONObject(p)
         holder!!.bind(jsonObject)
 
-        holder.itemView.setOnClickListener() {
-            context.startActivity(Intent(context, FormGeneratorActivity::class.java))
-        }
+        holder.itemView.setOnClickListener(mCLickListener)
     }
 }

--- a/app/src/main/res/layout/activity_listing.xml
+++ b/app/src/main/res/layout/activity_listing.xml
@@ -32,14 +32,21 @@
             android:drawableEnd="@drawable/ic_keyboard_arrow_up" />
     </LinearLayout>
 
-    <android.support.v7.widget.RecyclerView
-    android:id="@+id/recycler_view"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_weight="8"
-    tools:layout_editor_absoluteY="60dp">
+    <android.support.v4.widget.SwipeRefreshLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/swipeRefresh"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    </android.support.v7.widget.RecyclerView>
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="8"
+            tools:layout_editor_absoluteY="60dp">
+
+        </android.support.v7.widget.RecyclerView>
+    </android.support.v4.widget.SwipeRefreshLayout>
 
     <ProgressBar
         android:id="@+id/edit_progress_bar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="sort_name">Name</string>
     <string name="filters">Filters</string>
     <string name="actionSort">Sort</string>
+    <string name="shareData">Check out AgriNext, a Central Hub to connect all farmers.</string>
 
     <!-- OAUTH -->
     <string name="package_name">org.agrinext.agrimobile</string>


### PR DESCRIPTION
Invite will open list of all apps that are capable to send data.

App crashes wherever docMetaJson is used because it hasn't been initialised. The FrappeClient call takes time to save meta in SharedPreferences and setupDoctype needs to be called again to store metaJson after the frappeClient call.

OnClick event to start FormGeneratorActivity moved to ListingActivity rather than ListViewAdapter - better practice and ease in code.

Swipe Down to Refresh added to reload data from server. - Tested and Working!